### PR TITLE
Fix HTML detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (opt) {
         // - Optional byte-order mark (BOM)
         // - Zero or more spaces
         // - Any sort of valid HTML tag or doctype tag (basically, <...>)
-        return /^(\uFEFF|\uFFFE)?\s*<[:_\-\w\s\!\/\=\"\']+>/i.test(str);
+        return /^(\uFEFF|\uFFFE)?\s*<[:_\-\w\s\!\/\=\"\'.]+>/i.test(str);
     }
 
     function exists(body) {


### PR DESCRIPTION
The old regexp didn't match DOCTYPE declarations like this:

``` html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
```

More details here: https://github.com/shakyShane/grunt-browser-sync/issues/68#issuecomment-51725803
