### PR TITLE
Upgrade Minimatch to prevent RexExp DoS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "minimatch": "^2.0.1"
+    "minimatch": "^3.0.2"
   },
   "devDependencies": {
     "browser-sync": "^2.8.2",


### PR DESCRIPTION
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue